### PR TITLE
Add wellness plan savings calculator

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -1,0 +1,748 @@
+{
+  "plans": [
+    {
+      "planName": "Puppy",
+      "annualCost": 626.0,
+      "percentDiscount": 0.05,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Deworming Treatment",
+          "retailPrice": 26.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP 4dx Test",
+          "retailPrice": 53.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 47.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP Influenza",
+          "retailPrice": 64.0,
+          "planPrice": 61.0
+        },
+        {
+          "name": "WP Lyme",
+          "retailPrice": 59.0,
+          "planPrice": 56.0
+        },
+        {
+          "name": "WP Radiographs",
+          "retailPrice": 248.0,
+          "planPrice": 229.0
+        },
+        {
+          "name": "WP Canine Neuter",
+          "retailPrice": 375.0,
+          "planPrice": 339.0
+        },
+        {
+          "name": "WP Canine Spay",
+          "retailPrice": 497.0,
+          "planPrice": 449.0
+        }
+      ]
+    },
+    {
+      "planName": "Canine Foundation",
+      "annualCost": 566.0,
+      "percentDiscount": 0.1,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP 4dx Test",
+          "retailPrice": 53.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Blood Chemistry",
+          "retailPrice": 122.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 47.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP Influenza",
+          "retailPrice": 64.0,
+          "planPrice": 61.0
+        },
+        {
+          "name": "WP Lyme",
+          "retailPrice": 59.0,
+          "planPrice": 56.0
+        },
+        {
+          "name": "WP Canine Neuter",
+          "retailPrice": 375.0,
+          "planPrice": 339.0
+        },
+        {
+          "name": "WP Canine Spay",
+          "retailPrice": 497.0,
+          "planPrice": 508.0
+        },
+        {
+          "name": "WP Dental Radiographs",
+          "retailPrice": 125.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "WP Dental Prophylaxis",
+          "retailPrice": 606.0,
+          "planPrice": 449.0
+        },
+        {
+          "name": "WP Radiographs",
+          "retailPrice": 248.0,
+          "planPrice": 229.0
+        },
+        {
+          "name": "WP Urinalysis",
+          "retailPrice": 68.0,
+          "planPrice": 65.0
+        },
+        {
+          "name": "WP Blood Chemistry",
+          "retailPrice": 122.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 51.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 37.0,
+          "planPrice": 34.0
+        }
+      ]
+    },
+    {
+      "planName": "Canine Ultimate",
+      "annualCost": 878.0,
+      "percentDiscount": 0.15,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP 4dx Test",
+          "retailPrice": 53.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Urinalysis",
+          "retailPrice": 68.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Blood Chemistry (Senior Chem17/18)",
+          "retailPrice": 149.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP DHPP/ DHLPP/ Lepto",
+          "retailPrice": 49.0,
+          "planPrice": 47.0
+        },
+        {
+          "name": "WP Bordetella",
+          "retailPrice": 41.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP Influenza",
+          "retailPrice": 64.0,
+          "planPrice": 61.0
+        },
+        {
+          "name": "WP Lyme",
+          "retailPrice": 59.0,
+          "planPrice": 56.0
+        },
+        {
+          "name": "WP Canine Neuter",
+          "retailPrice": 375.0,
+          "planPrice": 339.0
+        },
+        {
+          "name": "WP Canine Spay",
+          "retailPrice": 497.0,
+          "planPrice": 508.0
+        },
+        {
+          "name": "WP Dental Radiographs",
+          "retailPrice": 125.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "WP Dental Prophylaxis",
+          "retailPrice": 606.0,
+          "planPrice": 449.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 51.0
+        },
+        {
+          "name": "WP Blood Chemistry (Senior Chem17/18)",
+          "retailPrice": 149.0,
+          "planPrice": 137.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 35.0,
+          "planPrice": 34.0
+        },
+        {
+          "name": "WP Radiographs",
+          "retailPrice": 248.0,
+          "planPrice": 229.0
+        }
+      ]
+    },
+    {
+      "planName": "Kitten",
+      "annualCost": 602.0,
+      "percentDiscount": 0.05,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FELV",
+          "retailPrice": 45.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Deworming Treatment",
+          "retailPrice": 26.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "IDEXX: Feline Combo",
+          "retailPrice": 47.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP Feline Neuter",
+          "retailPrice": 236.0,
+          "planPrice": 216.0
+        },
+        {
+          "name": "WP Feline Spay",
+          "retailPrice": 337.0,
+          "planPrice": 316.0
+        },
+        {
+          "name": "WP Radiographs",
+          "retailPrice": 248.0,
+          "planPrice": 229.0
+        }
+      ]
+    },
+    {
+      "planName": "Feline Foundation",
+      "annualCost": 554.0,
+      "percentDiscount": 0.1,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FELV",
+          "retailPrice": 45.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "IDEXX: Feline Combo",
+          "retailPrice": 47.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Blood Chemistry",
+          "retailPrice": 122.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP FELV",
+          "retailPrice": 45.0,
+          "planPrice": 43.0
+        },
+        {
+          "name": "WP Feline Neuter",
+          "retailPrice": 236.0,
+          "planPrice": 216.0
+        },
+        {
+          "name": "WP Feline Spay",
+          "retailPrice": 337.0,
+          "planPrice": 343.0
+        },
+        {
+          "name": "WP Dental Radiographs",
+          "retailPrice": 125.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "WP Dental Prophylaxis",
+          "retailPrice": 606.0,
+          "planPrice": 449.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 51.0
+        },
+        {
+          "name": "WP Blood Chemistry",
+          "retailPrice": 122.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 37.0,
+          "planPrice": 34.0
+        },
+        {
+          "name": "WP Radiographs",
+          "retailPrice": 248.0,
+          "planPrice": 229.0
+        },
+        {
+          "name": "WP Urinalysis",
+          "retailPrice": 68.0,
+          "planPrice": 65.0
+        }
+      ]
+    },
+    {
+      "planName": "Feline Ultimate",
+      "annualCost": 878.0,
+      "percentDiscount": 0.15,
+      "includedServices": [
+        {
+          "name": "WP Comprehensive Physical Exam: Biannual",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP FELV",
+          "retailPrice": 45.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Rabies",
+          "retailPrice": 35.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Fecal Float",
+          "retailPrice": 41.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "IDEXX: Feline Combo",
+          "retailPrice": 47.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Urinalysis",
+          "retailPrice": 68.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Blood Chemistry (Senior Chem17/18)",
+          "retailPrice": 149.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 37.0,
+          "planPrice": 0.0
+        },
+        {
+          "name": "WP Nail Trim",
+          "retailPrice": 25.0,
+          "planPrice": 0.0
+        }
+      ],
+      "optionalServices": [
+        {
+          "name": "nan",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "OPTIONAL ITEMS",
+          "retailPrice": NaN,
+          "planPrice": NaN
+        },
+        {
+          "name": "WP Additional Office Visit",
+          "retailPrice": 69.0,
+          "planPrice": 67.0
+        },
+        {
+          "name": "WP FVRCP",
+          "retailPrice": 37.0,
+          "planPrice": 35.0
+        },
+        {
+          "name": "WP FELV",
+          "retailPrice": 45.0,
+          "planPrice": 43.0
+        },
+        {
+          "name": "WP Feline Neuter",
+          "retailPrice": 236.0,
+          "planPrice": 216.0
+        },
+        {
+          "name": "WP Feline Spay",
+          "retailPrice": 337.0,
+          "planPrice": 343.0
+        },
+        {
+          "name": "WP Dental Radiographs",
+          "retailPrice": 125.0,
+          "planPrice": 116.0
+        },
+        {
+          "name": "WP Dental Prophylaxis",
+          "retailPrice": 606.0,
+          "planPrice": 449.0
+        },
+        {
+          "name": "WP Complete Blood Cell Count",
+          "retailPrice": 52.0,
+          "planPrice": 51.0
+        },
+        {
+          "name": "WP Blood Chemistry (Senior Chem17/18)",
+          "retailPrice": 149.0,
+          "planPrice": 137.0
+        },
+        {
+          "name": "Electrolytes",
+          "retailPrice": 35.0,
+          "planPrice": 34.0
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Wellness Plan Savings Calculator</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+<style>
+body { padding: 2rem; }
+.select-container { margin-top: 1rem; }
+.output { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1 class="title">Veterinary Wellness Plan Savings</h1>
+
+  <div class="field">
+    <label class="label" for="plan-select">Select Plan</label>
+    <div class="control">
+      <div class="select">
+        <select id="plan-select">
+          <option value="" disabled selected>Select a plan</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <div id="plan-details" style="display:none;">
+    <div class="columns">
+      <div class="column">
+        <label class="label" for="included">Included Services Used</label>
+        <div class="select is-multiple is-fullwidth select-container">
+          <select id="included" multiple size="8"></select>
+        </div>
+      </div>
+      <div class="column">
+        <label class="label" for="optional">Optional Services Received</label>
+        <div class="select is-multiple is-fullwidth select-container">
+          <select id="optional" multiple size="8"></select>
+        </div>
+      </div>
+    </div>
+
+    <div class="field">
+      <label class="label" for="additional">Additional Spend Not Covered ($)</label>
+      <div class="control">
+        <input class="input" type="number" id="additional" min="0" step="0.01" value="0">
+      </div>
+    </div>
+
+    <div class="output">
+      <p><strong>Total cost with plan:</strong> $<span id="with-plan">0.00</span></p>
+      <p><strong>Total cost without plan:</strong> $<span id="without-plan">0.00</span></p>
+      <p><strong>Estimated savings:</strong> $<span id="savings">0.00</span></p>
+    </div>
+  </div>
+</div>
+
+<script>
+let plans = [];
+let currentPlan = null;
+const planSelect = document.getElementById('plan-select');
+const includedSelect = document.getElementById('included');
+const optionalSelect = document.getElementById('optional');
+const additionalInput = document.getElementById('additional');
+const withPlanEl = document.getElementById('with-plan');
+const withoutPlanEl = document.getElementById('without-plan');
+const savingsEl = document.getElementById('savings');
+
+function formatMoney(value){
+  return value.toFixed(2);
+}
+
+function populateSelect(selectEl, items){
+  selectEl.innerHTML = '';
+  items.forEach((svc, idx) => {
+    if (isNaN(svc.retailPrice) || isNaN(svc.planPrice)) return; // skip invalid entries
+    const opt = document.createElement('option');
+    opt.value = idx;
+    opt.textContent = svc.name + ` ($${svc.retailPrice})`;
+    selectEl.appendChild(opt);
+  });
+}
+
+function calculate(){
+  if(!currentPlan) return;
+  const includedSelected = Array.from(includedSelect.selectedOptions).map(o => currentPlan.includedServices[o.value]);
+  const optionalSelected = Array.from(optionalSelect.selectedOptions).map(o => currentPlan.optionalServices[o.value]);
+  const additional = parseFloat(additionalInput.value) || 0;
+
+  const costWithPlan = currentPlan.annualCost +
+    optionalSelected.reduce((sum, svc) => sum + (parseFloat(svc.planPrice)||0), 0) +
+    additional;
+
+  const costWithout = includedSelected.reduce((sum, svc) => sum + (parseFloat(svc.retailPrice)||0), 0) +
+    optionalSelected.reduce((sum, svc) => sum + (parseFloat(svc.retailPrice)||0), 0) +
+    additional;
+
+  withPlanEl.textContent = formatMoney(costWithPlan);
+  withoutPlanEl.textContent = formatMoney(costWithout);
+  savingsEl.textContent = formatMoney(costWithout - costWithPlan);
+}
+
+function onPlanChange(){
+  const idx = planSelect.value;
+  if(idx === '') return;
+  currentPlan = plans[idx];
+  document.getElementById('plan-details').style.display = 'block';
+  populateSelect(includedSelect, currentPlan.includedServices);
+  populateSelect(optionalSelect, currentPlan.optionalServices);
+  includedSelect.selectedIndex = -1;
+  optionalSelect.selectedIndex = -1;
+  additionalInput.value = 0;
+  calculate();
+}
+
+fetch('data/plans.json')
+  .then(res => res.json())
+  .then(data => {
+    plans = data.plans || [];
+    plans.forEach((plan, idx) => {
+      const option = document.createElement('option');
+      option.value = idx;
+      option.textContent = plan.planName;
+      planSelect.appendChild(option);
+    });
+  });
+
+planSelect.addEventListener('change', onPlanChange);
+includedSelect.addEventListener('change', calculate);
+optionalSelect.addEventListener('change', calculate);
+additionalInput.addEventListener('input', calculate);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add veterinary plan data at `data/plans.json`
- create a single-page calculator `index.html` that loads plan data and computes savings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686590707e6c832581b4dbf505c91a9c