### PR TITLE
Update default quantities and input behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,8 @@ function populateServices(container, services, cls){
     input.type = 'number';
     input.min = 0;
     input.max = 9;
-    input.value = 0;
+    input.value = cls === 'included' ? 1 : 0;
+    input.addEventListener('focus', e => e.target.select());
     input.dataset.index = idx;
     input.className = `${cls}-qty input`;
     input.style.width = '4rem';
@@ -150,6 +151,7 @@ fetch('data/plans.json')
 
 planSelect.addEventListener('change', onPlanChange);
 additionalInput.addEventListener('input', calculate);
+additionalInput.addEventListener('focus', e => e.target.select());
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- preload included services with quantity 1
- keep optional service quantities at 0
- auto-select number fields on focus so typing replaces old value

## Testing
- `node -e "const p=require('./data/plans.json');console.log(Object.keys(p));"`

------
https://chatgpt.com/codex/tasks/task_e_6865a101b3a88325b6eab54b472d8923