### PR TITLE
Add clinic logo to interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@ body { padding: 2rem; }
 .no-spinner {
   -moz-appearance: textfield;
 }
+/* Clinic logo sizing */
+.clinic-logo {
+  max-height: 60px;
+}
 #clinic-header,
 #print-summary-container {
   display: none;
@@ -34,7 +38,8 @@ body { padding: 2rem; }
 <section class="section">
   <div class="container">
     <section class="hero is-info">
-      <div class="hero-body">
+      <div class="hero-body is-flex is-align-items-center">
+        <img src="assets/Logo.png" alt="Clinic Logo" class="clinic-logo mr-3">
         <h1 class="title">Veterinary Wellness Plan Savings</h1>
       </div>
     </section>
@@ -227,6 +232,7 @@ function buildPrintSummary(){
   }).join('');
 
   printContainer.innerHTML = `
+    <img src="assets/Logo.png" alt="Clinic Logo" class="clinic-logo mb-3">
     <h1 class="title is-4">Wellness Plan Summary</h1>
     <p>${new Date().toLocaleDateString()}</p>
     <h2 class="subtitle is-5">Plan: ${currentPlan.planName}</h2>

--- a/print.css
+++ b/print.css
@@ -26,3 +26,8 @@ body {
   background: none !important;
   border: 1px solid #000;
 }
+
+/* Logo sizing on printed summary */
+.clinic-logo {
+  max-height: 60px;
+}


### PR DESCRIPTION
## Summary
- include a `clinic-logo` class with 60px max height
- show the clinic logo next to the header title
- insert the logo at the top of the print summary
- style the logo in print styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686699dff5f883259cdf2a5e73e134f8